### PR TITLE
Italian update

### DIFF
--- a/app/src/main/assets/about-it.html
+++ b/app/src/main/assets/about-it.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="it" xml:lang="it">
 	<head>
-		<title>Informazioni su Chess</title>
+		<title>Informazioni su Scacchi</title>
 				<style type="text/css">
 h3, h4 {
 	background-color: #97C03D;
@@ -32,10 +32,10 @@ td {
 
 <p>Creato da <i>Jeroen Carolus</i></p>
 
-<p>Per supporto, informazioni su aggiornamenti e ultima versione: consulta il sito web dello sviluppatore <a href='http://www.jwtc.nl/'>jwtc.nl</a>.</p>
+<p>Per supporto, informazioni riguardo gli aggiornamenti, e per l'ultima versione dell'applicazione, consulta il sito web dello sviluppatore <a href='http://www.jwtc.nl/'>jwtc.nl</a>.</p>
 
 <p>Si ringrazia <i>Peter van Grijfland</i> per il coinvolgimento, gli eccellenti suggerimenti e il beta testing.</p>
-<p>Contributi attraverso GitHub:</p>
+<p>Contributi da GitHub:</p>
 <p><i>Paolo Straffi</i>: Traduzione italiana.</p>
 
 	</body>

--- a/app/src/main/assets/convergence-it.html
+++ b/app/src/main/assets/convergence-it.html
@@ -12,14 +12,14 @@
 
 <h3>Schermo TV Scacchi - sperimentale</h3>
 
-<p>Questa funzionalità vi dà la possibilità di permettere ad un altro dispositivo di mostrare la scacchiera nel caso sia sulla stessa rete locale (LAN).</p>
-<p>Al momento, questa funzionalità è sperimentale e le concrete applicazioni per Smart-TV che possono connettersi al vostro dispositivo Android non sono ancora disponibili.</p>
-<p>Contattatemi se desiderate fare beta testing (se possedete una Smart TV)</p>
-<p>Passo 1. Premere il bottone "Start" dalla finestra "Share screen" sul vostro dispositivo Android</p>
-<p>Passo 2. Avviare l'applicazione "Chess screen" sulla vostra TV</p>
-<p>Passo 3. Inserire il numero mostrato sotto il bottone "Start" usando il telecomando della vostra TV.</p>
+<p>Questa funzionalit&agrave; consente a un altro dispositivo della stessa rete locale (LAN) di mostrare la scacchiera.</p>
+<p>Al momento la funzionalit&agrave; &egrave; sperimentale e le applicazioni per Smart-TV che possono connettersi al vostro dispositivo Android non sono ancora disponibili.</p>
+<p>Contattami se desideri fare beta testing (se possiedi una Smart TV)</p>
+<p>Passo 1. Premi il pulsante "Start" dalla finestra "Share screen" sul tuo dispositivo Android</p>
+<p>Passo 2. Avvia l'applicazione "Chess screen" sulla tua TV</p>
+<p>Passo 3. Inserisci il numero mostrato sotto il pulsante "Start" usando il telecomando della tua TV.</p>
 <p>--------------------</p>
-<p>Vuoi testare questa funzionalità da un normale browser sul tuo PC o laptop? - vai all'indirizzo http://jwtc.nl/tv</p>
+<p>Vuoi testare questa funzionalit&agrave; da un normale browser installato sul tuo PC o portatile? - vai all'indirizzo http://jwtc.nl/tv</p>
 
 </div>
 

--- a/app/src/main/assets/help-it.html
+++ b/app/src/main/assets/help-it.html
@@ -14,36 +14,36 @@
 
 <p>Creato da <i>Jeroen Carolus</i></p>
 
-<p>Per supporto, informazioni su aggiornamenti e ultima versione: consulta il sito web dello sviluppatore <a href="http://www.jwtc.nl/">jwtc.nl</a>.</p>
+<p>Per supporto, informazioni riguardo gli aggiornamenti, e per l'ultima versione dell'applicazione, consulta il sito web dello sviluppatore <a href='http://www.jwtc.nl/'>jwtc.nl</a>.</p>
 
 <p>Si ringrazia <i>Peter van Grijfland</i> per il coinvolgimento, gli eccellenti suggerimenti e il beta testing.</p>
 
-<p><a href="https://github.com/jcarolus/android-chess">Scacchi è su GitHub</a> - contribuisci e rendila una app migliore!</p>
-<p>Contributi attraverso GitHub:</p>
+<p><a href="https://github.com/jcarolus/android-chess">Scacchi &egrave; ospitato su GitHub</a> - contribuisci e rendila un'app migliore!</p>
+<p>Contributi da GitHub:</p>
 <p><i>Paolo Straffi</i>: Traduzione italiana.</p>
 
 <h4>Gioco</h4>
-<p>Gioca vs. Android o usa una scacchiera per analizzare le partite.
+<p>Gioca contro Android o usa una scacchiera per analizzare le partite.
 </p>
 
 <h4>Pratica</h4>
-<p>Esercita le tue abilità di arrivare allo scacco matto contro l'orologio.
+<p>Esercita le tue abilit&agrave; per arrivare allo scacco matto in una sfida a tempo.
 </p>
 
-<h4>Enigmi</h4>
-<p>Risolvi enigmi difficili di "matto in due mosse".
+<h4>Problemi</h4>
+<p>Risolvi problemi difficili di "matto in due mosse".
 </p>
 
-<h4>Gioco online</h4>
+<h4>Gioca online</h4>
 <p>Gioca online su FICS (Free Internet Chess Server).
 </p>
 
-<h4>Preferenze Globali</h4>
-<p>Imposta le preferenze globali degli scacchi.
+<h4>Preferenze</h4>
+<p>Imposta le preferenze globali dell'applicazione Chess.
 </p>
 
 <h4>Avanzate</h4>
-<p>Importa ed esporta gli strumenti che si occupano dei file PGN.
+<p>Strumenti per importare ed esportare file PGN.
 </p>
 
 </div>

--- a/app/src/main/assets/help_online-it.html
+++ b/app/src/main/assets/help_online-it.html
@@ -12,20 +12,20 @@
 	<h3>Gioca online - Aiuto</h3>
 
 <p>
-<strong>FICS: Free Internet Chess Server</strong> permette di giocare con migliaia di giocatori di scacchi online.<br/>
-Attenzione: se il tuo dispositivo commuta da un access point internet ad un altro, la connessione può interrompersi. Timeseal non è implementato.<br/>
+<strong>FICS: Free Internet Chess Server</strong> permette di giocare online con migliaia di giocatori di scacchi.<br/>
+Attenzione: se il tuo dispositivo passa da un Internet access point a un altro, la connessione pu&ograve; interrompersi. Nessun timeseal &egrave; implementato.<br/>
 </p>
 <h4>Menu</h4>
 <strong>Sfide</strong><br/>
-Chi è alla ricerca di un match. Clicca su un giocatore nella lista per accettare la sfida.<br/>
+Chi &egrave; alla ricerca di un match. Clicca su un giocatore nella lista per accettare la sfida.<br/>
 <strong>Cerca</strong><br/>
-Imposta la tua sfida. Se inserisci il nome di un giocatore che conosci, avrai una sfida diretta.<br/>
+Imposta la tua sfida. Se inserisci il nome di un giocatore che conosci potrai sfidarlo direttamente.<br/>
 <strong>Partite</strong><br/>
-Assisti a partite giocate online. Un gran maestro può essere identificato dal prefisso GM davanti al nome. 
+Guarda le partite che si stanno giocando online. Un gran maestro pu&ograve; essere identificato dal prefisso GM davanti al nome.
 
-<h4>Bottoni</h4>
-I tre bottoni sullo schermo possono essere usati per:<br/>
-- aggiungere un prefisso al testo inserito per commutare tra un comando personalizzato o una chat<br/>
+<h4>Pulsanti</h4>
+I tre pulsanti sullo schermo possono essere usati per:<br/>
+- aggiungere un prefisso al testo inserito per eseguire un comando personalizzato o una chat<br/>
 - accedere alla lista di funzioni utili<br/>
 - aprire un'ampia console di testo
 

--- a/app/src/main/assets/help_pgntool-it.html
+++ b/app/src/main/assets/help_pgntool-it.html
@@ -2,7 +2,7 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="it" xml:lang="it">
 	<head>
-		<title>Advanced</title>
+		<title>Avanzate</title>
 		<link rel="stylesheet" type="text/css" href="style.css" />
 
 	</head>
@@ -10,34 +10,34 @@
 <body>
 <div class="content">
 	<h3>Avanzate</h3>
-	<p>Crea o importa il tuo materiale qui.</p>
+	<p>Crea o importa le tue cose qui.</p>
 	
-	<h4>Esporta il database di gioco nella sd-card</h4>
-	<p>Tutte le partite nel database di gioco possono essere esportate nella sd-card in un singolo file PGN. Questo file verrà denominato chess.pgn e un eventuale file esistente verrà sovrascritto.</p>
+	<h4>Esporta il database di gioco nella scheda SD</h4>
+	<p>Tutte le partite nel database possono essere esportate nella scheda SD in un singolo file PGN. Questo file verr&agrave; denominato chess.pgn e un eventuale file giÃ  esistente verr&agrave; sovrascritto.</p>
 	
 	<h4>Importa le partite nel database di gioco</h4>
-	<p>Usa questa opzione per aggiungere partite al database di gioco. L'opzione permette di navigare fino ad un file PGN. Seleziona e importa.</p>
+	<p>Usa questa opzione per aggiungere partite al database di gioco. L'opzione permette di navigare a un file PGN. Selezionalo per importarlo.</p>
 	
-	<h4>Cancella tutte le partite nel database di gioco</h4>
-	<p>Usa questa opzione se vuoi ripulire il database di gioco. Prima assicurati di aver fatto un backup sulla sd-card, poiché l'azione non può essere annullata.</p>
+	<h4>Cancella tutte le partite dal database di gioco</h4>
+	<p>Usa questa opzione se vuoi ripulire il database di gioco. Assicurati di aver fatto un backup nella scheda SD, poich&eacute; l'azione non pu&ograve; essere annullata.</p>
 	
-	<h4>Crea openingdatabase</h4>
-	<p>Naviga fino ad un file PGN sulla sd-card e questo verrà convertito in un openingdatabase con lo stesso nome ma con un nome file con estensione .bin. Attualmente tutte le partite nel file PGN saranno analizzate fino al 17 ply.</p>
+	<h4>Crea database delle aperture</h4>
+	<p>Naviga fino a un file PGN nella scheda SD e questo verr&agrave; convertito in un database delle aperture con lo stesso nome, ma con un nome di file con estensione .bin. Attualmente tutte le partite nel file PGN saranno analizzate fino alla mossa 17.</p>
 	
-	<h4>Imposta openingdatabase</h4>
-	<p>Naviga fino all'appena creato file .bin openingdatabase per permettere a Scacchi di utilizzarlo.</p>
+	<h4>Imposta database delle aperture</h4>
+	<p>Naviga fino al file .bin appena creato (database delle aperture) per permettere a Scacchi di utilizzarlo.</p>
 
 	<h4>Installa motore UCI</h4>
-	<p>Naviga fino al file binario del motore UCI per permettere a Scacchi di utilizzarlo.</p>
+	<p>Naviga fino al file binario del motore UCI per consentire a Scacchi di utilizzarlo.</p>
 	
 	<h4>Disinstalla motore UCI</h4>
 	<p>Elimina il motore UCI installato.</p>
 	
-	<h4>Crea pratica set</h4>
-	<p>Crea posizioni per la pratica dalle partite terminate con uno scacco matto. Naviga fino al file per elaborarlo. Le partite respinte normalmente lo sono perché non finiscono in uno scacco matto o sono dei duplicati</p>
+	<h4>Crea set di pratica</h4>
+	<p>Crea posizioni per la pratica dalle partite terminate con uno scacco matto. Naviga fino al file per elaborarlo. Le partite rifiutate normalmente lo sono perch&eacute; non finiscono in uno scacco matto o sono duplicati di altre partite</p>
 	
-	<h4>Azzera il set di pratica</h4>
-	<p>Vuoi ricominciare la pratica? Questa opzione azzererà anche il contatore del tempo medio.</p>
+	<h4>Azzera set di pratica</h4>
+	<p>Vuoi ricominciare la pratica? Questa opzione azzerer&agrave; anche il contatore del tempo medio.</p>
 
 </div>	
 </body>

--- a/app/src/main/assets/help_play-en.html
+++ b/app/src/main/assets/help_play-en.html
@@ -42,8 +42,8 @@ Set playing options<br/>
 
 <h4><a name="options"></a>Options</h4>
 <p>
-Check the box to play vs Android or uncheck for two player mode<br/>
-If you are in two player mode, you can check to rotate the board automatically after each move<br/>
+Check the box to play vs Android or uncheck for two player mode.<br/>
+If you are in two player mode, you can check to rotate the board automatically after each move.<br/>
 If you want to view the valid moves of the piece you selected to move, check the 'Show moves'.
 Set the maximum time Android is allowed to 'think'.<br/>
 </p>

--- a/app/src/main/assets/help_play-it.html
+++ b/app/src/main/assets/help_play-it.html
@@ -11,7 +11,7 @@
 <div class="content">
 	<h3>Scacchi - Aiuto</h3>
 
-<p><b>Per demo online e supporto consulta il sito web dello sviluppatore</b></p>
+<p><b>Per una prova online e supporto consulta il sito web dello sviluppatore</b></p>
 	
 <fieldset><legend tabindex="1">Indice</legend>
 <p><a href="#instructions">Istruzioni di gioco</a></p>
@@ -26,10 +26,10 @@
 
 
 <h4><a name="instructions"></a>Istruzioni di gioco</h4>
-<p>Per muovere un pezzo, selezionalo con un tocco. Puoi anche usare il pad direzionale o la trackball per selezionare una casella. Questa verrà evidenziata. 
-Quindi seleziona la posizione dove dovrebbe andare. Osserva il titolo per informazioni sul gioco come lo stato della partia o la legalità di una mossa.<br/>
-Clicca il bottone Gioca per far fare una mossa ad Android.<br/>
-Usa i bottoni di navigazione o la barra storica per navigare attraverso la storia della partita. Se torni indietro e fai una mossa da una posizione precedente del gioco, la storia della partita viene troncata da quel punto.<br/>
+<p>Per muovere un pezzo, selezionalo con un tocco. Puoi anche usare il pad direzionale o la trackball per selezionare una casella. Questa verr&agrave; evidenziata.
+Seleziona poi la posizione dove dovrebbe andare il pezzo. Osserva il titolo per informazioni sul gioco, come ad esempio lo stato della partia o la legalit&agrave; di una mossa.<br/>
+Clicca il pulsante Gioca per far fare una mossa ad Android.<br/>
+Usa i pulsanti di navigazione o la barra della cronologia per navigare attraverso la storia della partita. Se torni indietro e fai una mossa da una posizione precedente del gioco, la storia della partita viene interrotta fino a quel punto, e ripresa con le nuove mosse.<br/>
 
 </p>
 
@@ -42,44 +42,44 @@ Imposta opzioni di gioco<br/>
 
 <h4><a name="options"></a>Opzioni</h4>
 <p>
-Spunta la casella gioca vs Android oppure deseleziona la casella per giocare in modalità due giocatori<br/>
-Se sei nella modalità due giocatori, puoi spuntare l'opzione per ruotare la scacchiera automaticamente dopo ciascuna mossa<br/>
+Spunta la casella Gioca vs Android, oppure deseleziona la casella per giocare in modalit&agrave; due giocatori.<br/>
+Se sei nella modalit&agrave; due giocatori, puoi spuntare l'opzione per ruotare la scacchiera automaticamente dopo ciascuna mossa.<br/>
 Se desideri vedere le mosse valide per il pezzo selezionato, spunta 'Mostra mosse'.
 Imposta il tempo massimo concesso ad Android per 'pensare'.<br/>
 </p>
 
 <h4><a name="views"></a>Interfaccia utente</h4>
 <p>
-Premi il bottone 'more' per commutare la posizione dei controlli tra una delle seguenti:<br/>
-Veduta di default 'giocatore' con bottoni di navigazione.<br/>
+Premi il pulsante 'piÃ¹ opzioni' per cambiare a uno dei seguenti controlli:<br/>
+Interfaccia di default 'giocatore' con pulsanti di navigazione.<br/>
 Pezzi catturati.<br/>
 Orologio. Premi l'icona dell'orologio per impostare il tempo.<br/>
-Mostra annotazioni. Clicca sull'area testo per scrivere.
+Mostra annotazioni. Clicca sull'area di testo per scrivere.
 Storia PGN.<br/>
 </p>
 
 <h4><a name="save"></a>Carica e salva</h4>
 <p>
-Puoi salvare la partita in corso nella lista delle partite salvate attraverso il menu. Scegli 'Salva partita' e riempi i campi della finestra di dialogo.<br/>
-<strong>Nota:</strong> La partita in corso verrà salvata automaticamente perché se dovesse arrivare una chiamata, il programma potrebbe esserre terminato e quindi non sarebbe possibile chiedere se si vuole salvare o no la partita.<br/>
+Puoi salvare la partita in corso nella lista delle partite salvate attraverso il menu. Scegli 'Salva partita' e riempi i campi della finestra di dialogo, in modo da poter ritrovare la nuovamente la partita.<br/>
+<strong>Nota:</strong> La partita in corso verr&agrave; salvata automaticamente perch&eacute; altrimenti se dovesse arrivare una chiamata il programma potrebbe esserre terminato, e non sarebbe possibile scegliere se salvare o meno la partita.<br/>
 Per caricare una partita salvata, scegli 'Carica partita' dal menu.<br/>
 </p>
 
 <h4><a name="import"></a>Importa una partita</h4>
 <p>
-Se qualcuno ti ha inviato una e-mail con un file pgn, puoi farlo aprire a Scacchi. <br/>
-Puoi anche usare lo strumento dedicato a PGN per navigare fino al file pgn sulla tua SD-card e importare le partite.<br/>
+Se qualcuno ti ha inviato una email con un file PGN, puoi farlo aprire a Scacchi. <br/>
+Puoi anche usare lo strumento dedicato a PGN per navigare fino al file sulla tua scheda SD e importare le partite.<br/>
 </p>
 
 <h4><a name="export"></a>Esporta una partita</h4>
 <p>
-Puoi inviare via e-mail la partita che stai visualizzando con il selezionare 'E-mail game' nel menu. Così avvierai il tuo client e-mail con una e-mail che contiene la partita come un allegato pgn. <br/>
+Puoi inviare via email la partita che stai visualizzando selezionando 'Invia partita via email' nel menu. In questo modo avvierai il tuo client di posta elettronica con una email che contiene la partita come un allegato PGN.<br/>
 </p>
 
 <h4><a name="tips"></a>Suggerimenti</h4>
 <p>
-Usa l'orologio e imposta il tempo a 2 o 5 minuti. Prova a battere Android prima della fine del tempo. Non dimenticare di impostare il livello di gioco di Android ad un livello adeguato (2 secondi)<br/>
-Usa gli Scacchi 960 per rendere la sfida più stimolante.<br/>
+Usa l'orologio e imposta il tempo a 2 o 5 minuti. Prova a battere Android prima della fine del tempo. Non dimenticare di impostare il livello di gioco di Android ad un livello adeguato (2 secondi a mossa).<br/>
+Usa gli Scacchi 960 per rendere la sfida pi&ugrave; stimolante.<br/>
 </p>
 
 </div>

--- a/app/src/main/assets/help_practice-it.html
+++ b/app/src/main/assets/help_practice-it.html
@@ -11,15 +11,15 @@
 	<h3>Pratica - Aiuto</h3>
 
 <p>
-Trova lo scacco matto (può volerci più di una mossa).<br/>
-Il tempo e il tempo medio per posizione è mostrato accanto alla scacchiera.<br/>
-Premi il bottone 'Mostra'per vedere la soluzione.<br/>
-Premi il bottone 'Seguente' per andare alla posizione successiva.<br/>
-Talvolta possono essere trovate molteplici soluzioni, ma l'applicazione ne accetta solamente una.
+Trova lo scacco matto (potrebbe volerci pi&ugrave; di una mossa).<br/>
+Il tempo e il tempo medio per posizione &egrave; mostrato accanto alla scacchiera.<br/>
+Premi il pulsante 'Mostra' per vedere la soluzione.<br/>
+Premi il pulsante 'Successivo' per andare alla posizione successiva.<br/>
+Talvolta possono essere trovate pi&ugrave; soluzioni, ma l'applicazione ne accetta solamente una.
 </p>
 
 <p>
-Questa applicazione contiene 2000 sequenze di matti forzati riprese dalle partite di grandi maestri.
+Questa applicazione contiene 2000 sequenze di matti forzati prese dalle partite di grandi maestri.
 </p>
 </div>
 	</body>

--- a/app/src/main/assets/help_puzzle-it.html
+++ b/app/src/main/assets/help_puzzle-it.html
@@ -2,20 +2,20 @@
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="it" xml:lang="it">
 	<head>
-		<title>Enigmi | Aiuto</title>
+		<title>Problemi | Aiuto</title>
 		<link rel="stylesheet" type="text/css" href="style.css" />
 	</head>
 
 	<body>
 <div class="content">
-	<h3>Enigmi - Aiuto</h3>
+	<h3>Problemi - Aiuto</h3>
 
 <p>
-Questi sono difficili enigmi di <strong>Matto in due mosse</strong>.<br/>
-L'obiettivo è quello di <strong>trovare la prima mossa</strong> che conduce ad un matto forzato entro due mosse.<br/>
-In altre parole, dopo che hai fatto la mossa corretta, l'avversario non può impedire il matto derivante dalla tua prossima mossa.<br/>
-Dopo questa prima mossa, l'enigma è risolto.<br/>
-Premi il bottone 'Mostra' per avere la soluzione.<br/>
+Questi sono problemi difficili di <strong>Matto in due mosse</strong>.<br/>
+L'obiettivo &egrave; quello di <strong>trovare la prima mossa</strong> che conduce a un matto forzato entro due mosse.<br/>
+In altre parole, dopo che hai fatto la mossa corretta, l'avversario non pu&ograve; impedire il matto derivante dalla tua prossima mossa.<br/>
+Dopo questa prima mossa il problema &egrave; risolto.<br/>
+Premi il pulsante 'Mostra' per avere la soluzione.<br/>
 </p>
 <p>
 Fonte: <strong>EL ARTE DEL MATE EN DOS</strong> di <i>Eduardo Sadier</i>

--- a/app/src/main/assets/help_setup-it.html
+++ b/app/src/main/assets/help_setup-it.html
@@ -12,10 +12,10 @@
 	
 <p><b>Imposta una posizione sulla scacchiera</b></p>
 <p>Tocca uno dei pezzi sotto la scacchiera per selezionarlo, quindi tocca la casella dove desideri posizionarlo.<br/>
-Per rimuovere un pezzo, seleziona il pezzo, quindi clicca il bottone cancella.<br/>
+Per rimuovere un pezzo, seleziona il pezzo, quindi clicca il pulsante cancella.<br/>
 Per muovere un pezzo, selezionalo e tocca la casella dove desideri che vada.<br/>
 Per cambiare il colore di un nuovo pezzo, seleziona il quadrato accanto alla <b>X</b>.<br/>
-Quando hai fatto, clicca la casella di spunta. 
+Quando hai finito, seleziona la casella.
 </p>
 </div>
 	</body>

--- a/app/src/main/java/jwtc/android/chess/ics/ICSMatchDlg.java
+++ b/app/src/main/java/jwtc/android/chess/ics/ICSMatchDlg.java
@@ -84,7 +84,7 @@ public class ICSMatchDlg extends Dialog {
 				}
 				Log.i("ICSMatchDlg", s);
 				_parent.sendString(s);
-				Toast.makeText(_parent, "Challenge posted", Toast.LENGTH_SHORT).show();
+				Toast.makeText(_parent, R.string.toast_challenge_posted, Toast.LENGTH_SHORT).show();
 			}
         });
 	    _butCancel = (Button)findViewById(R.id.ButtonMatchCancel);

--- a/app/src/main/java/jwtc/android/chess/start.java
+++ b/app/src/main/java/jwtc/android/chess/start.java
@@ -78,7 +78,7 @@ public class start extends Activity/*ListActivity*/  {
 					} 
 					
 				} catch(Exception ex){
-					Toast t = Toast.makeText(start.this, "Could not start the activity", Toast.LENGTH_LONG);
+					Toast t = Toast.makeText(start.this, R.string.toast_could_not_start_activity, Toast.LENGTH_LONG);
 					t.setGravity(Gravity.BOTTOM, 0, 0);
 					t.show();
 				}

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -11,16 +11,16 @@
 		<item>@string/start_exit</item>
 	</string-array>
     <string-array name="levels_ply">
-        <item>1 ply</item>
-        <item>2 ply</item>
-        <item>3 ply</item>
-        <item>4 ply</item>
-        <item>5 ply</item>
-        <item>6 ply</item>
-        <item>7 ply</item>
-        <item>8 ply</item>
-        <item>9 ply</item>
-        <item>10 ply</item>
+        <item>1 mossa</item>
+        <item>2 mosse</item>
+        <item>3 mosse</item>
+        <item>4 mosse</item>
+        <item>5 mosse</item>
+        <item>6 mosse</item>
+        <item>7 mosse</item>
+        <item>8 mosse</item>
+        <item>9 mosse</item>
+        <item>10 mosse</item>
     </string-array>
     <string-array name="levels_time">
         <item>@string/choice_level_1</item>
@@ -70,8 +70,8 @@
     </integer-array>
      -->
     <string-array name="options_wakelock">
-    	<item>Usa sospensione</item>
-    	<item>Non usare sospensione</item>
+    	<item>Usa blocco sospensione</item>
+    	<item>Non usare blocco sospensione</item>
     </string-array>
      <string-array name="match_time_minutes">
         <item>0</item><item>1</item><item>2</item><item>3</item><item>4</item><item>5</item>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -119,7 +119,7 @@
     	<item>@string/pgntool_help</item>
     </string-array>
     <string-array name="tileKeyArray">
-    	<item></item>
+    	<item/>
     	<item>shade</item>
     	<item>shade_bottom</item>
     	<item>stripes</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -100,7 +100,7 @@
 <string name="title_pick_colorscheme">Scegli colore</string>
 <string name="title_pick_playmode">Scegli modalità di gioco</string>
 <string name="title_create_new_line">Crea nuova linea?</string>
-<string name="title_chess960_manual_random">Scacchi 960 :: scelta del numero manuale o casuale?</string>
+<string name="title_chess960_manual_random">Scacchi 960 :: numero di posizione scelto manualmente o casuale?</string>
 <string name="title_edit_or_delete">Modifica o cancella?</string>
 <string name="title_edit_command">Modifica comando</string>
 <string name="title_ics_mode_idle">In attesa</string>
@@ -115,7 +115,7 @@
 <string name="menu_new">Nuova partita</string>
 <string name="menu_clear">Libera</string>
 <string name="menu_options">Opzioni</string>
-<string name="menu_email_game">Gioca via e-mail</string>
+<string name="menu_email_game">Invia partita via email</string>
 <string name="menu_clip_pgn">Copia partita negli appunti</string>
 <string name="menu_fromclip">Richiama partita dagli appunti</string>
 <string name="menu_save_game">Salva partita</string>
@@ -147,7 +147,7 @@
 <string name="menu_subview_guess">Indovina la mossa</string>
 <string name="menu_subview_blindfold">Modalità alla cieca</string>
 
-<string name="options_play_android">Giocatore vs Android</string>
+<string name="options_play_android">Gioca vs Android</string>
 <string name="options_960">Scacchi 960 - Fischer Random</string>
 <string name="options_load_database">Carica database aperture</string>
 <string name="options_auto_flip">Auto-inversione scacchiera</string>
@@ -179,7 +179,7 @@
 <string name="choice_level_8">1 minuto</string>
 <string name="choice_level_9">5 minuti</string>
 <string name="choice_level_10">15 minuti</string>
-<string name="choice_queen">Regina</string>
+<string name="choice_queen">Donna</string>
 <string name="choice_rook">Torre</string>
 <string name="choice_bishop">Alfiere</string>
 <string name="choice_knight">Cavallo</string>
@@ -205,7 +205,7 @@
 <string name="msg_setup_castle_black">Nero</string>
 <string name="msg_setup_extra">Premi menu per le opzioni di setup</string>
 <string name="msg_qr_code_on_clipboard">Link al QR Code copiato negli appunti&#8230;</string>
-<string name="chess960_position_nr">"Scacchi 960 positione n. %d"</string>
+<string name="chess960_position_nr">"Scacchi 960 posizione n. %d"</string>
 <string name="msg_ics_enter_handle">Inserisci il tuo nome</string>
 <string name="msg_ics_enter_password">Inserisci la password</string>
 <string name="msg_progress">Progresso:</string>
@@ -218,7 +218,7 @@
 La scheda SD deve essere montata per elaborare la tua richiesta.
 </string>
 <string name="err_send_email">
-L\'e-mail potrebbe non essere stata creata.
+L\'email potrebbe non essere stata creata.
 </string>
 <string name="err_load_fen">La posizione FEN potrebbe non essere stata caricata</string>
 <string name="err_load_pgn">La storia PGN potrebbe non essere stata caricata</string>
@@ -229,19 +229,19 @@ L\'e-mail potrebbe non essere stata creata.
 
 <string name="pgntool_export_explanation">Esporta il database di gioco nella scheda SD</string>
 <string name="pgntool_import_explanation">Importa le partite nel database di gioco</string>
-<string name="pgntool_delete_explanation">Cancella tutte le partite nel database di gioco</string>
+<string name="pgntool_delete_explanation">Cancella tutte le partite dal database di gioco</string>
 <string name="pgntool_add_db_explanation">Aggiungi partite al database delle aperture</string>
 <string name="pgntool_create_db_explanation">Crea database delle aperture</string>
 <string name="pgntool_point_db_explanation">Imposta database delle aperture</string>
 <string name="pgntool_point_uci_engine">Installa motore UCI</string>
 <string name="pgntool_unset_uci_engine">Disinstalla motore UCI</string>
 <string name="pgntool_help">Aiuto</string>
-<string name="pgntool_numexport">Esportata partita %1$d in chess.pgn</string>
+<string name="pgntool_numexport">Partita %1$d esportata in chess.pgn</string>
 <string name="pgntool_confirm_delete">Sei sicuro?</string>
 <string name="pgntool_deleted">Tutte le partite sono state cancellate</string>
 <string name="pgntool_create_practice_explanation">Crea set di pratica</string>
 <string name="pgntool_import_practice">Importa set di pratica</string>
-<string name="pgntool_reset_practice">Azzera pratica - ricomincia</string>
+<string name="pgntool_reset_practice">Azzera set di pratica</string>
 <string name="pgntool_confirm_practice_reset">Sei sicuro di voler azzerare?</string>
 <string name="pgntool_import_puzzle">Importa problemi</string>
 <string name="pgntool_import_opening">Usato dallo sviluppatore</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -288,4 +288,8 @@ L\'email potrebbe non essere stata creata.
 <string name="ics_welcome_format">Benvenuto <b>%1$s</b></string>
 <string name="ics_start_text">(password vuota per accedere come ospite)</string>
 
+<!-- Toast strings -->
+<string name="toast_could_not_start_activity">Impossibile avviare l\'Activity</string>
+<string name="toast_challenge_posted">Sfida lanciata</string>
+
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -4,18 +4,18 @@
 <string name="app_name">Scacchi</string>
 <string name="app_name_play">Scacchi - gioca</string>
 <string name="app_name_playonline">Scacchi - gioca online</string>
-<string name="app_name_setup">Scacchi - Impostazioni</string>
+<string name="app_name_setup">Scacchi - impostazioni</string>
 <string name="app_name_help">Scacchi - aiuto</string>
 <string name="app_name_import">Scacchi - importa</string>
 <string name="app_name_pgntools">Scacchi - avanzate</string>
-<string name="app_name_save_games">Giochi salvati</string>
+<string name="app_name_save_games">Partite salvate</string>
 
 <string name="language">it</string>
 
 <string name="start_play">Gioca</string>
 <string name="start_lessons">Lezioni</string>
 <string name="start_practice">Pratica</string>
-<string name="start_puzzles">Enigmi</string>
+<string name="start_puzzles">Problemi</string>
 <string name="start_about">Informazioni</string>
 <string name="start_pgn">Avanzate</string>
 <string name="start_ics">Gioca online</string>
@@ -23,9 +23,9 @@
 <string name="start_exit">Esci</string>
 <string name="start_convergence">Schermo TV</string>
 
-<string name="globalpreferences">Scacchi - preferenze globali</string>
+<string name="globalpreferences">Scacchi - preferenze</string>
 <string name="pref_wakelock">Usa blocco sospensione</string>
-<string name="pref_wakelock_desc">Questo impedirà al telefono di andare in sospensione</string>
+<string name="pref_wakelock_desc">Impedisce al telefono di andare in sospensione</string>
 <string name="pref_colorscheme">Schema colori</string>
 <string name="pref_colorscheme_desc">Colore delle caselle della schacchiera</string>
 <string name="pref_showCoords">Coordinate</string>
@@ -36,28 +36,28 @@
 <string name="pref_sound_desc">Eseguito quando l\'avversario muove</string>
 <string name="pref_speech">Parlato</string>
 <string name="pref_speech_desc">Comunica la mossa fatta (in inglese)</string>
-<string name="pref_eco">ECO info</string>
+<string name="pref_eco">Info ECO</string>
 <string name="pref_eco_desc">Mostra informazioni di apertura ECO quando disponibili</string>
 <string name="pref_extrahighlight">Evidenziazione extra</string>
 <string name="pref_extrahighlight_desc">Rende l\'evidenziazione della mossa più visibile</string>
-<string name="pref_fullscreen">Abilita lo schermo intero</string>
-<string name="pref_fullscreen_desc">Consigliato per schermi piccoli e vista panoramica; in caso contrario gli elementi possono cadere fuori dallo schermo</string>
+<string name="pref_fullscreen">Abilita schermo intero</string>
+<string name="pref_fullscreen_desc">Consigliato per schermi piccoli e rotazione orizzontale del display. Se non attivata gli elementi potrebbero uscire dallo schermo</string>
 <string name="pref_onLoadJumpToLastMove">Vai all\'ultima mossa</string>
-<string name="pref_onLoadJumpToLastMove_desc">Quando si ritorna all\'App, si salta all\'ultima mossa</string>
+<string name="pref_onLoadJumpToLastMove_desc">Dopo essere tornati all\'App, salta all\'ultima mossa</string>
 <string name="pref_uci">Motore UCI</string>
 <string name="pref_uci_desc">Seleziona il motore scacchistico da usare</string>
 <string name="pref_pieceset">Set di pezzi</string>
-<string name="pref_pieceset_desc">Il tipo di set di pezzi utilizzato sulla scacchiera</string>
+<string name="pref_pieceset_desc">Tipologia di pezzi utilizzata sulla scacchiera</string>
 <string name="pref_tileset">Decorazione delle caselle</string>
 <string name="pref_tileset_desc">Decorazione usata sulle caselle della scacchiera</string>
 <string name="pref_icsconfirmmove">Conferma mossa</string>
-<string name="pref_icsconfirmmove_desc">Conferma manualmente mossa</string>
+<string name="pref_icsconfirmmove_desc">Conferma manuale della mossa</string>
 <string name="pref_icscustomcommand">Comandi personalizzati</string>
 <string name="pref_icscustomcommand_desc">Crea i tuoi comandi personalizzati</string>
 <string name="pref_icsautosought">Ricerca automatica</string>
-<string name="pref_icsautosought_desc">Aggiorna automaticamente lo schermo delle sfide</string>
+<string name="pref_icsautosought_desc">Aggiorna automaticamente la finestra delle sfide</string>
 <string name="pref_puzzle_show_seekbar">Mostra barra di ricerca</string>
-<string name="pref_puzzle_show_seekbar_desc">Naviga rapidamente attraverso gli enigmi con la barra di ricerca</string>
+<string name="pref_puzzle_show_seekbar_desc">Sfoglia rapidamente i problemi con la barra di ricerca</string>
 
 <string name="button_play">Gioca</string>
 <string name="button_undo">Annulla</string>
@@ -72,13 +72,13 @@
 <string name="button_new">Nuova</string>
 <string name="button_show">Mostra</string>
 
-<string name="alert_yes">Si</string>
+<string name="alert_yes">Sì</string>
 <string name="alert_no">No</string>
 <string name="alert_cancel">Annulla</string>
 <string name="alert_ok">OK</string>
 
 <string name="title_challenge">Sfida</string>
-<string name="title_loading">Caricamento...</string>
+<string name="title_loading">Caricamento&#8230;</string>
 <string name="title_error">Errore</string>
 <string name="title_offers_abort">Richiesta di interruzione</string>
 <string name="title_offers_takeback">Richiesta ritiro mossa</string>
@@ -90,24 +90,24 @@
 <string name="title_menu">Menu</string>
 <string name="title_welcome">Benvenuto</string>
 <string name="title_annotate">Annota</string>
-<string name="title_save_game">Salva gioco</string>
+<string name="title_save_game">Salva partita</string>
 <string name="title_options">Opzioni</string>
-<string name="title_delete_game">Cancella gioco</string>
+<string name="title_delete_game">Cancella partita</string>
 <string name="title_notice">Avviso</string>
 <string name="title_pick_promo">Scegli promozione pezzo</string>
 <string name="title_castle">Arroccare?</string>
-<string name="title_pick_en_passant">En-passant file</string>
+<string name="title_pick_en_passant">Colonna en-passant</string>
 <string name="title_pick_colorscheme">Scegli colore</string>
 <string name="title_pick_playmode">Scegli modalità di gioco</string>
 <string name="title_create_new_line">Crea nuova linea?</string>
-<string name="title_chess960_manual_random">Scacchi 960 :: posizionamento n. manuale o casuale?</string>
+<string name="title_chess960_manual_random">Scacchi 960 :: scelta del numero manuale o casuale?</string>
 <string name="title_edit_or_delete">Modifica o cancella?</string>
 <string name="title_edit_command">Modifica comando</string>
 <string name="title_ics_mode_idle">In attesa</string>
 <string name="title_ics_mode_play">Gioca</string>
 <string name="title_ics_mode_watch">Osserva</string>
 <string name="title_ics_mode_examine">Esamina</string>
-<string name="title_ics_mode_puzzle">Enigma</string>
+<string name="title_ics_mode_puzzle">Problema</string>
 <string name="title_ics_mode_endgame">Finale di partita</string>
 <string name="title_installing">Installazione</string>
 
@@ -121,22 +121,22 @@
 <string name="menu_save_game">Salva partita</string>
 <string name="menu_load_game">Carica partita</string>
 <string name="menu_random_fischer">Scacchi 960</string>
-<string name="menu_puzzles">Enigmi</string>
+<string name="menu_puzzles">Problemi</string>
 <string name="menu_practice">Pratica</string>
 <string name="menu_pgn_tool">Strumento PGN</string>
 <string name="menu_about">Informazioni</string>
 <string name="menu_exit">Esci</string>
 <string name="menu_flip">Inverti la scacchiera</string>
-<string name="menu_more">Altro…</string>
+<string name="menu_more">Altro&#8230;</string>
 <string name="menu_setup">Disponi la scacchiera</string>
-<string name="menu_from_qrcode">Da QR-code</string>
-<string name="menu_to_qrcode">A QR-code</string>
+<string name="menu_from_qrcode">Da QR Code</string>
+<string name="menu_to_qrcode">A QR Code</string>
 <string name="menu_new_command">Nuovo comando</string>
 <string name="menu_set_clock">Imposta orologio</string>
 <string name="menu_start">Avvia</string>
 <string name="menu_stop">Ferma</string>
-<string name="menu_test_convergence">Testa convergenza</string>
-<string name="menu_test_DIAL">Testa DIAL</string>
+<string name="menu_test_convergence">Prova convergenza</string>
+<string name="menu_test_DIAL">Prova DIAL</string>
 
 <string name="menu_subview_title">Scegli sottocontrolli</string>
 <string name="menu_subview_cpu">Informazioni motore</string>
@@ -157,10 +157,10 @@
 
 <string name="state_play">in gioco</string>
 <string name="state_draw">patta</string>
-<string name="state_draw_material">patta(per pezzi)</string>
+<string name="state_draw_material">patta (per pezzi)</string>
 <string name="state_draw_50">patta (regola delle 50 mosse)</string>
 <string name="state_draw_stalemate">patta (stallo)</string>
-<string name="state_draw_repeat">patta (mossa ripetuta 3 volte)</string>
+<string name="state_draw_repeat">patta (3 ripetizioni)</string>
 <string name="state_mate">matto</string>
 <string name="state_check">scacco</string>
 <string name="state_time">tempo</string>
@@ -193,18 +193,18 @@
 
 <string name="msg_illegal_move">Mossa illegale</string>
 <string name="msg_state_format">%1$s</string>
-<string name="msg_thinking">Sto riflettendo...</string>
-<string name="msg_wait">Per favore attendere...</string>
+<string name="msg_thinking">Sto riflettendo&#8230;</string>
+<string name="msg_wait">Per favore attendere&#8230;</string>
 <string name="msg_calc_format">Mossa %1$s\tStima %2$s</string>
 <string name="msg_calc_summary_format">Sommario motore: %1$s</string>
 <string name="msg_setup_turn">Turno</string>
 <string name="msg_setup_turn_white">bianco</string>
 <string name="msg_setup_turn_black">nero</string>
-<string name="msg_setup_enpassant">Casella en-passant</string>
+<string name="msg_setup_enpassant">Colonna en-passant</string>
 <string name="msg_setup_castle_white">Bianco</string>
 <string name="msg_setup_castle_black">Nero</string>
 <string name="msg_setup_extra">Premi menu per le opzioni di setup</string>
-<string name="msg_qr_code_on_clipboard">Link al codice QR copiato negli appunti...</string>
+<string name="msg_qr_code_on_clipboard">Link al QR Code copiato negli appunti&#8230;</string>
 <string name="chess960_position_nr">"Scacchi 960 positione n. %d"</string>
 <string name="msg_ics_enter_handle">Inserisci il tuo nome</string>
 <string name="msg_ics_enter_password">Inserisci la password</string>
@@ -215,24 +215,24 @@
 <string name="msg_server">Impossibile avviare il server</string>
 
 <string name="err_sd_not_mounted">
-Al fine di elaborare la tua richiesta, la SD-card deve essere montata.
+La scheda SD deve essere montata per elaborare la tua richiesta.
 </string>
 <string name="err_send_email">
 L\'e-mail potrebbe non essere stata creata.
 </string>
-<string name="err_load_fen">La posizione scacchistica FEN potrebbe non essere stata caricata</string>
-<string name="err_load_pgn">La storia scacchistica PGN potrebbe non essere stata caricata</string>
-<string name="err_no_clip_text">Non c\'è testo negli appunti</string>
+<string name="err_load_fen">La posizione FEN potrebbe non essere stata caricata</string>
+<string name="err_load_pgn">La storia PGN potrebbe non essere stata caricata</string>
+<string name="err_no_clip_text">Appunti vuoti</string>
 <string name="err_install_barcode_scanner">Per favore installa uno scanner di codici a barre (ZXing)</string>
 <string name="err_chess960_position_range">Posizione non valida, inserisci un numero tra 0 e 960</string>
 <string name="err_chess960_postion_format">Posizione non valida, inserisci un numero</string>
 
-<string name="pgntool_export_explanation">Esporta il database di gioco nella sd-card</string>
+<string name="pgntool_export_explanation">Esporta il database di gioco nella scheda SD</string>
 <string name="pgntool_import_explanation">Importa le partite nel database di gioco</string>
 <string name="pgntool_delete_explanation">Cancella tutte le partite nel database di gioco</string>
-<string name="pgntool_add_db_explanation">Aggiungi partite a openingdatabase</string>
-<string name="pgntool_create_db_explanation">Crea openingdatabase</string>
-<string name="pgntool_point_db_explanation">Imposta openingdatabase</string>
+<string name="pgntool_add_db_explanation">Aggiungi partite al database delle aperture</string>
+<string name="pgntool_create_db_explanation">Crea database delle aperture</string>
+<string name="pgntool_point_db_explanation">Imposta database delle aperture</string>
 <string name="pgntool_point_uci_engine">Installa motore UCI</string>
 <string name="pgntool_unset_uci_engine">Disinstalla motore UCI</string>
 <string name="pgntool_help">Aiuto</string>
@@ -241,9 +241,9 @@ L\'e-mail potrebbe non essere stata creata.
 <string name="pgntool_deleted">Tutte le partite sono state cancellate</string>
 <string name="pgntool_create_practice_explanation">Crea set di pratica</string>
 <string name="pgntool_import_practice">Importa set di pratica</string>
-<string name="pgntool_reset_practice">Azzera pratica - ricomincia </string>
+<string name="pgntool_reset_practice">Azzera pratica - ricomincia</string>
 <string name="pgntool_confirm_practice_reset">Sei sicuro di voler azzerare?</string>
-<string name="pgntool_import_puzzle">Importa enigmi</string>
+<string name="pgntool_import_puzzle">Importa problemi</string>
 <string name="pgntool_import_opening">Usato dallo sviluppatore</string>
 
 <string name="ics_client_handle">Nome utente</string>
@@ -270,14 +270,14 @@ L\'e-mail potrebbe non essere stata creata.
 <string name="ics_menu_closeboard">Chiudi scacchiera</string>
 <string name="ics_menu_console">Console</string>
 <string name="ics_menu_unobserve">Ferma osservazione</string>
-<string name="ics_menu_stop_puzzle">Ferma enigma</string>
+<string name="ics_menu_stop_puzzle">Ferma problema</string>
 
 <string name="ics_progress_title_login">Accedi</string>
-<string name="ics_progress_msg_login">Stai accedendo...</string>
-<string name="ics_offers_abort">Il tuo avversario vorrebbe interrompere la partita.\nDesideri accettare?</string>
-<string name="ics_offers_draw">Il tuo avversario offre una patta.\nDesideri accettare?</string>
-<string name="ics_offers_adjourn">Il tuo avversario vorrebbe aggiornare la partita.\nDesideri accettare?</string>
-<string name="ics_offers_takeback">Il tuo avversario vorrebbe ritirare la mossa.\nDesideri accettare?</string>
+<string name="ics_progress_msg_login">Stai accedendo&#8230;</string>
+<string name="ics_offers_abort">Il tuo avversario vorrebbe interrompere la partita.\nVuoi accettare?</string>
+<string name="ics_offers_draw">Il tuo avversario offre una patta.\nVuoi accettare?</string>
+<string name="ics_offers_adjourn">Il tuo avversario vorrebbe aggiornare la partita.\nVuoi accettare?</string>
+<string name="ics_offers_takeback">Il tuo avversario vorrebbe ritirare la mossa.\nVuoi accettare?</string>
 <string name="ics_request_sent">Richiesta inviata</string>
 <string name="ics_game_over">Partita fermata</string>
 <string name="ics_game_over_format">Fine partita: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
 <string name="alert_ok">OK</string>
 
 <string name="title_challenge">Challenge</string>
-<string name="title_loading">Loading...</string>
+<string name="title_loading">Loading&#8230;</string>
 <string name="title_error">Error</string>
 <string name="title_offers_abort">Abort request</string>
 <string name="title_offers_takeback">Take back request</string>
@@ -193,8 +193,8 @@
 
 <string name="msg_illegal_move">Illegal move</string>
 <string name="msg_state_format">%1$s</string>
-<string name="msg_thinking">Thinking...</string>
-<string name="msg_wait">Please wait...</string>
+<string name="msg_thinking">Thinking&#8230;</string>
+<string name="msg_wait">Please wait&#8230;</string>
 <string name="msg_calc_format">Move %1$s\tEvaluations %2$s</string>
 <string name="msg_calc_summary_format">Engine summary: %1$s</string>
 <string name="msg_setup_turn">Turn</string>
@@ -204,7 +204,7 @@
 <string name="msg_setup_castle_white">White</string>
 <string name="msg_setup_castle_black">Black</string>
 <string name="msg_setup_extra">Press menu for setup options</string>
-<string name="msg_qr_code_on_clipboard">Link to QR code is on your clipboard...</string>
+<string name="msg_qr_code_on_clipboard">Link to QR code is on your clipboard&#8230;</string>
 <string name="chess960_position_nr">"Chess 960 position nr %d"</string>
 <string name="msg_ics_enter_handle">Please enter your handle</string>
 <string name="msg_ics_enter_password">Please enter your password</string>
@@ -273,7 +273,7 @@ E-mail could not be created.
 <string name="ics_menu_stop_puzzle">Stop puzzle</string>
 
 <string name="ics_progress_title_login">Log in</string>
-<string name="ics_progress_msg_login">Logging you in...</string>
+<string name="ics_progress_msg_login">Logging you in&#8230;</string>
 <string name="ics_offers_abort">Your opponent would like to abort the game.\nDo you wish to accept?</string>
 <string name="ics_offers_draw">Your opponent offers you a draw.\nDo you wish to accept?</string>
 <string name="ics_offers_adjourn">Your opponent would like to adjourn the game.\nDo you wish to accept?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,7 +241,7 @@ E-mail could not be created.
 <string name="pgntool_deleted">All games deleted</string>
 <string name="pgntool_create_practice_explanation">Create practice set</string>
 <string name="pgntool_import_practice">Import practice set</string>
-<string name="pgntool_reset_practice">Reset practice - start over </string>
+<string name="pgntool_reset_practice">Reset practice - start over</string>
 <string name="pgntool_confirm_practice_reset">Are you sure you want to reset?</string>
 <string name="pgntool_import_puzzle">Import puzzles</string>
 <string name="pgntool_import_opening">Used by developer</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,4 +288,8 @@ E-mail could not be created.
 <string name="ics_welcome_format">Welcome <b>%1$s</b></string>
 <string name="ics_start_text">(password empty to login as guest)</string>
 
+<!-- Toast strings -->
+<string name="toast_could_not_start_activity">Could not start the activity</string>
+<string name="toast_challenge_posted">Challenge posted</string>
+
 </resources>


### PR DESCRIPTION
Updated Italian translation in resources and HTML files. I took care about some typos and some too much literal translations from English. For example chess puzzle is "[problema](http://it.wikipedia.org/wiki/Problema_di_scacchi)", not "enigma".

I also extracted two strings from Java code to string resources. In this way I was able to translate them, since they are visible to user.