### PR TITLE
add bring app to front

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -194,4 +194,6 @@
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.VIBRATE" />
+	<uses-permission android:name="android.permission.GET_TASKS" />
+	<uses-permission android:name="android.permission.REORDER_TASKS" />
 </manifest>

--- a/app/src/main/java/jwtc/android/chess/ics/ICSChessView.java
+++ b/app/src/main/java/jwtc/android/chess/ics/ICSChessView.java
@@ -32,7 +32,8 @@ public class ICSChessView extends ChessViewBase {
 
     private JNI _jni;
     //private Button _butAction;
-    private TextView _tvPlayerTop, _tvPlayerBottom, _tvClockTop, _tvClockBottom, _tvBoardNum, _tvLastMove;
+    private TextView _tvPlayerTop, _tvPlayerBottom, _tvPlayerTopRating, _tvPlayerBottomRating,
+            _tvClockTop, _tvClockBottom, _tvBoardNum, _tvLastMove;
 
     //private EditText _editChat;
     private Button _butConfirmMove, _butCancelMove;
@@ -93,6 +94,9 @@ public class ICSChessView extends ChessViewBase {
 
         _tvPlayerTop = (TextView) _activity.findViewById(R.id.TextViewTop);
         _tvPlayerBottom = (TextView) _activity.findViewById(R.id.TextViewBottom);
+
+        _tvPlayerTopRating = (TextView) _activity.findViewById(R.id.TextViewICSTwoRating);
+        _tvPlayerBottomRating = (TextView) _activity.findViewById(R.id.TextViewICSOneRating);
 
         _tvClockTop = (TextView) _activity.findViewById(R.id.TextViewClockTop);
         _tvClockBottom = (TextView) _activity.findViewById(R.id.TextViewClockBottom);
@@ -463,31 +467,37 @@ public class ICSChessView extends ChessViewBase {
 
             if (_flippedBoard) {
                 _tvPlayerTop.setText(_whitePlayer);
+                _tvPlayerTopRating.setText(_parent.get_whiteRating());
                 _tvPlayerBottom.setText(_blackPlayer);
+                _tvPlayerBottomRating.setText(_parent.get_blackRating());
                 _tvClockTop.setText(parseTime(_iWhiteRemaining));
                 _tvClockBottom.setText(parseTime(_iBlackRemaining));
             } else {
                 _tvPlayerTop.setText(_blackPlayer);
+                _tvPlayerTopRating.setText(_parent.get_blackRating());
                 _tvPlayerBottom.setText(_whitePlayer);
+                _tvPlayerBottomRating.setText(_parent.get_whiteRating());
                 _tvClockTop.setText(parseTime(_iBlackRemaining));
                 _tvClockBottom.setText(parseTime(_iWhiteRemaining));
             }
 
-            // the last move
+
             st.nextToken();
-            String sMove = st.nextToken();
+            st.nextToken();  // machine last move
+            st.nextToken();  // time per move
+            String sMove = st.nextToken();  // algebraic last move
 
             //int iFrom = -1;
-            if (false == sMove.equals("none") && sMove.length() > 2) {
+            if (false == sMove.equals("none") && sMove.length() > 1) {
 
-                _tvLastMove.setText(sMove);
+                _tvLastMove.setText(_iTurn==1 ? ".." + sMove: sMove);  // display last move
 
-                if (sMove.equals("o-o")) {
+                if (sMove.equals("O-O")) {
                     if (_iTurn == BoardConstants.WHITE)
                         m_iTo = Pos.fromString("g8");
                     else
                         m_iTo = Pos.fromString("g1");
-                } else if (sMove.equals("o-o-o")) {
+                } else if (sMove.equals("O-O-O")) {
                     if (_iTurn == BoardConstants.WHITE)
                         m_iTo = Pos.fromString("c8");
                     else

--- a/app/src/main/java/jwtc/android/chess/ics/ICSChessView.java
+++ b/app/src/main/java/jwtc/android/chess/ics/ICSChessView.java
@@ -243,6 +243,7 @@ public class ICSChessView extends ChessViewBase {
                             break;
                     default: Log.e(TAG, "get_gameStartSound error");
                 }
+                _parent.bringAPPtoFront();
                 Log.i(TAG, "Play");
                 break;
             case VIEW_WATCH:

--- a/app/src/main/java/jwtc/android/chess/ics/ICSClient.java
+++ b/app/src/main/java/jwtc/android/chess/ics/ICSClient.java
@@ -52,7 +52,8 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
 
     private TelnetSocket _socket;
     private Thread _workerTelnet;
-    private String _server, _handle, _pwd, _prompt, _waitFor, _buffer, _ficsHandle, _ficsPwd, _sFile, _FEN = "";
+    private String _server, _handle, _pwd, _prompt, _waitFor, _buffer, _ficsHandle, _ficsPwd,
+            _sFile, _FEN = "", _whiteRating, _blackRating;
     private int _port, _serverType, _TimeWarning, _gameStartSound;
     private boolean _bIsGuest, _bInICS, _bAutoSought, _bTimeWarning, _bEndBuf, _bEndGameDialog, _gameStartFront;
     private Button _butLogin;
@@ -92,8 +93,7 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
     // Suffocate (++++) seeking 30 30 unrated standard [black] m ("play 29" to respond)
     //Pattern _pattSeeking = Pattern.compile("(\\w+) \\((.+)\\) seeking (\\d+) (\\d+) (rated |unrated ?)(standard |blitz |lightning )(\\[white\\] |\\[black\\] )?(f |m )?\\(\"play (\\d+)\" to respond\\)");
 
-    private Pattern _pattSought;
-    private Pattern _pattGameRow;
+    private Pattern _pattSought, _pattGameRow;
     private Pattern _pattChat = Pattern.compile("(\\w+)(\\(\\w+\\))? tells you\\: (.+)");
 
     //1269.allko                    ++++.kaspalesweb(U)
@@ -1050,6 +1050,25 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
 
                     /////////////////////////////////////////////////////////////////
                     // game created
+                    else if (line.contains("Creating:")){
+                        //               1         2       3         4      5      6   7 8
+                        //Creating: bunnyhopone (++++) mardukedog (++++) unrated blitz 5 5
+                        Pattern _pattCreateGame = Pattern.compile("Creating: (\\w+) (\\(.{3,4}\\)) (\\w+) (\\(.{3,4}\\)) (\\w+) (\\w+) (\\d+) (\\d+)");
+                        Matcher mat = _pattCreateGame.matcher(line);
+
+                        if (mat.matches()){
+                            _whiteRating = mat.group(2);
+                            _whiteRating = _whiteRating.replaceAll("[()]", "");
+                            if (_whiteRating.equals("++++")){
+                                _whiteRating = "UNR";
+                            }
+                            _blackRating = mat.group(4);
+                            _blackRating = _blackRating.replaceAll("[()]", "");
+                            if (_blackRating.equals("++++")){
+                                _blackRating = "UNR";
+                            }
+                        }
+                    }
                     else if (line.indexOf("{Game ") >= 0 && (line.indexOf(" Creating ") > 0 || line.indexOf(" Continuing ") > 0)) {
                         Pattern p = Pattern.compile("\\{Game (\\d+) .*");
                         Matcher m = p.matcher(line);
@@ -1576,6 +1595,14 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
 
     public int get_gameStartSound(){
         return _gameStartSound;
+    }
+
+    public String get_whiteRating(){
+        return _whiteRating;
+    }
+
+    public String get_blackRating(){
+        return _blackRating;
     }
 
     public boolean isConnected() {

--- a/app/src/main/java/jwtc/android/chess/ics/ICSClient.java
+++ b/app/src/main/java/jwtc/android/chess/ics/ICSClient.java
@@ -1,5 +1,6 @@
 package jwtc.android.chess.ics;
 
+import android.app.ActivityManager;
 import android.app.AlertDialog;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
@@ -53,7 +54,7 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
     private Thread _workerTelnet;
     private String _server, _handle, _pwd, _prompt, _waitFor, _buffer, _ficsHandle, _ficsPwd, _sFile, _FEN = "";
     private int _port, _serverType, _TimeWarning, _gameStartSound;
-    private boolean _bIsGuest, _bInICS, _bAutoSought, _bTimeWarning, _bEndBuf, _bEndGameDialog;
+    private boolean _bIsGuest, _bInICS, _bAutoSought, _bTimeWarning, _bEndBuf, _bEndGameDialog, _gameStartFront;
     private Button _butLogin;
     private TextView _tvHeader, _tvConsole, _tvPlayConsole;
 //	public ICSChatDlg _dlgChat;
@@ -284,7 +285,6 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
         ImageButton butClose = (ImageButton)findViewById(R.id.ButtonBoardClose);
         butClose.setOnClickListener(new OnClickListener() {
         	public void onClick(View arg0) {
-        		// TODO
         		unsetBoard();
         		switchToWelcomeView();
         	}
@@ -1520,6 +1520,8 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
         _bEndGameDialog = prefs.getBoolean("ICSEndGameDialog", true);
 
         _gameStartSound = Integer.parseInt(prefs.getString("ICSGameStartSound", "1"));
+
+        _gameStartFront = prefs.getBoolean("ICSGameStartBringToFront", true);
         /////////////////////////////////////////////////////////////////
 
         if (_ficsHandle == null) {
@@ -1581,6 +1583,25 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
             return false;
         }
         return true;
+    }
+
+    public void bringAPPtoFront(){
+
+        if (_gameStartFront) {
+
+            ActivityManager am = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
+            List<ActivityManager.RunningTaskInfo> tasklist = am.getRunningTasks(10); // Number of tasks you want to get
+
+            if (!tasklist.isEmpty()) {
+                int nSize = tasklist.size();
+                for (int i = 0; i < nSize; i++) {
+                    ActivityManager.RunningTaskInfo taskinfo = tasklist.get(i);
+                    if (taskinfo.topActivity.getPackageName().equals("jwtc.android.chess")) {
+                        am.moveTaskToFront(taskinfo.id, 0);
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/icsclient.xml
+++ b/app/src/main/res/layout/icsclient.xml
@@ -15,7 +15,7 @@
 	     >
 	     	 <TableLayout android:layout_width="fill_parent" android:layout_height="wrap_content"
 		    	android:id="@+id/TablePlayerTop" 
-		    	android:stretchColumns="1"
+		    	android:stretchColumns="2"
 		    	android:layout_marginBottom="2dip"
 		    >
 		    	<TableRow>
@@ -27,9 +27,15 @@
 					/>
 				    <TextView android:text="@string/ics_playertwo" android:id="@+id/TextViewTop"
 				    	android:layout_height="wrap_content"
-				    	android:layout_width="fill_parent"   
+				    	android:layout_width="wrap_content"
 				    	style="@style/MyHeaderTextStyle"
-				    />	
+				    />
+					<TextView android:text="----" android:id="@+id/TextViewICSTwoRating"
+						android:layout_height="wrap_content"
+						android:layout_width="fill_parent"
+						style="@style/MyHeaderTextStyle"
+						android:layout_marginLeft="3dip"
+					/>
 				     <TextView android:id="@+id/TextViewICSBoardNum"
 						android:text="# 0"
 						style="@style/MyHeaderTextStyle"
@@ -52,7 +58,7 @@
 		    <TableLayout android:layout_width="fill_parent" android:layout_height="wrap_content"
 		    	android:id="@+id/TablePlayerBottom" android:layout_below="@id/includeboard"
 		    	android:layout_marginTop="2dip"
-		    	android:stretchColumns="1"
+		    	android:stretchColumns="2"
 		    >
 		    	<TableRow>
 			    	<TextView android:id="@+id/TextViewClockBottom"
@@ -63,11 +69,17 @@
 					/>
 				    <TextView android:text="@string/ics_playerone" android:id="@+id/TextViewBottom"
 				    	android:layout_height="wrap_content" 
-				    	android:layout_width="fill_parent"  
+				    	android:layout_width="wrap_content"
 				    	style="@style/MyHeaderTextStyle"
 				    />
+					<TextView android:text="----" android:id="@+id/TextViewICSOneRating"
+							  android:layout_height="wrap_content"
+							  android:layout_width="fill_parent"
+							  style="@style/MyHeaderTextStyle"
+							  android:layout_marginLeft="3dip"
+					/>
 				    <TextView android:id="@+id/TextViewICSBoardLastMove"
-						android:text="./.-."
+						android:text="---"
 						style="@style/MyNormalTextStyle"
 						android:layout_width="70dip" android:layout_height="wrap_content"
 					/>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -65,6 +65,8 @@
 <string name="prefs_icsendgamesummary">Al final de un juego, ¿quieres un ahorro de diálogo en Emergente?</string>
 <string name="pref_icsgamestartsound">Juego Sonido inicial</string>
 <string name="pref_icsgamestartsound_desc">Reproducir sonido cuando el juego comienza, o pérdida de la conexión</string>
+<string name="pref_icsgamestartfront">Inicia Juego Traer al frente</string>
+<string name="prefs_icsgamestartfrontsummary">intentar traer aplicación de ajedrez al frente cuando se inicia el juego</string>
 <string name="pref_puzzle_show_seekbar">Mostrar barra de búsqueda</string>
 <string name="pref_puzzle_show_seekbar_desc">Navegar rápidamente a través de rompecabezas con la barra de búsqueda</string>
 <string name="pref_localelanguage">Ajuste el idioma</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -65,6 +65,8 @@
 <string name="prefs_icsendgamesummary">Alla fine di una partita, vuoi una finestra di dialogo Salva per PopUp?</string>
 <string name="pref_icsgamestartsound">Gioco Suono Inizio</string>
 <string name="pref_icsgamestartsound_desc">Riproduci suono quando gioco inizia o la perdita di collegamento</string>
+<string name="pref_icsgamestartfront">Inizia Gioco Porta in primo piano</string>
+<string name="prefs_icsgamestartfrontsummary">cercare di portare gli scacchi app in primo piano quando il gioco inizia</string>
 <string name="pref_puzzle_show_seekbar">Mostra barra di ricerca</string>
 <string name="pref_puzzle_show_seekbar_desc">Sfoglia rapidamente i problemi con la barra di ricerca</string>
 <string name="pref_localelanguage">Impostare la lingua</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,8 @@
 <string name="prefs_icsendgamesummary">At the end of a game, do you want a save dialog to popup?</string>
 <string name="pref_icsgamestartsound">Game Start Sound</string>
 <string name="pref_icsgamestartsound_desc">Play sound when game starts or loss of connection</string>
+<string name="pref_icsgamestartfront">Game Starts Bring to Front</string>
+<string name="prefs_icsgamestartfrontsummary">attempt to bring chess app to the front when the game starts</string>
 <string name="pref_puzzle_show_seekbar">Show seek bar</string>
 <string name="pref_puzzle_show_seekbar_desc">Quickly navigate through puzzles with seek bar</string>
 <string name="pref_localelanguage">Set The Language</string>

--- a/app/src/main/res/xml/icsprefs.xml
+++ b/app/src/main/res/xml/icsprefs.xml
@@ -50,6 +50,13 @@
             android:defaultValue="1"
             />
 
+        <CheckBoxPreference
+            android:title="@string/pref_icsgamestartfront"
+            android:defaultValue="true"
+            android:summary="@string/prefs_icsgamestartfrontsummary"
+            android:key="ICSGameStartBringToFront"
+            />
+
     </PreferenceCategory>
 
 §</PreferenceScreen>


### PR DESCRIPTION
The option to bring chess app to the front task when a game starts.  When browsing or in a different app and you hear your game start, instead of fumbling around for the chess app, the chess app should come to the front automatically. It uses PERMISSIONS get_task and reorder_task.