### PR TITLE
moved addConsoleText to bottom of sendString function

### DIFF
--- a/app/src/main/java/jwtc/android/chess/ics/ICSClient.java
+++ b/app/src/main/java/jwtc/android/chess/ics/ICSClient.java
@@ -1866,10 +1866,6 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
 
     public void sendString(String s) {
 
-        if (_bConsoleText){        // allows user ICS console text only
-            addConsoleText(s);
-            _bConsoleText = false;
-        }
 
         if (_socket == null || _socket.sendString(s + "\n") == false) {
             switch (get_gameStartSound()) {
@@ -1906,6 +1902,12 @@ public class ICSClient extends MyBaseActivity implements OnItemClickListener {
                         .show();
             } catch(Exception ex){
                 Log.e(TAG, ex.toString());
+            }
+            
+
+            if (_bConsoleText){        // allows user ICS console text only
+                addConsoleText(s);
+                _bConsoleText = false;
             }
         }
 


### PR DESCRIPTION
Strange behavior.  My galaxy s3 was not showing text after input.  When marked out addConsoleText, it would show text.  I moved addConsoleText to the bottom of the sendString function and now my galaxy s3 is showing text like it should.